### PR TITLE
Fix cloudhealth guid error and add basic acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ vet:
 	go tool vet *.go cloudhealth/*.go
 
 .PHONY: test
-test:
+test: vendor
 	go test ./cloudhealth
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -123,3 +123,20 @@ configuration.
 Merges are not supported. Nor are dynamic groups that include additional
 "filter" rules. You may get errors if you attemp to import a perspective that
 has either of these things.
+
+## Tests
+
+To run the tests, use
+
+```
+go test
+```
+
+To run acceptance tests, you must follow the instructions in [provider
+configuration](#provider-configuration) to set the `CHT_API_KEY` env variable.
+You must then run
+```
+TF_ACC=1 go test -v
+```
+
+Its probably also useful to enable logging by setting the `TF_LOG` env variable

--- a/cloudhealth/json_to_tf_test.go
+++ b/cloudhealth/json_to_tf_test.go
@@ -1,7 +1,6 @@
 package cloudhealth
 
 import (
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/yudai/gojsondiff"
@@ -295,11 +294,10 @@ func TestRenameAndReorderGroup(t *testing.T) {
 	newRD := resource.TestResourceData()
 	jsonToTF(b, newRD)
 
-	// The ref_id for the first group should be a UUID
+	// The first ref_id should be a higher int than the rest of the items in constants
 	refId := rd.Get("group.0.ref_id").(string)
 	assert.NotEqual(t, refId, "2")
-	_, err = uuid.ParseUUID(refId)
-	assert.Nil(t, err)
+	assert.Equal(t, "5", refId)
 
 	assertEqual(t, newRD, "group.0.name", "My New Name")
 	assertEqual(t, newRD, "group.1.ref_id", "1")

--- a/cloudhealth/provider_test.go
+++ b/cloudhealth/provider_test.go
@@ -3,9 +3,20 @@ package cloudhealth
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"cloudhealth": testAccProvider,
+	}
+}
 
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
@@ -15,4 +26,37 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
+}
+
+const testAccCreateConfig = `
+resource "cloudhealth_perspective" "acc_test_owner_tag" {
+  name               = "acc test owner tag"
+  include_in_reports = false
+	hard_delete        = true
+
+  group {
+    name = "OwnerAccTest"
+    type = "categorize"
+
+    rule {
+      asset     = "AwsAsset"
+      tag_field = ["owner"]
+    }
+  }
+}
+`
+
+func TestAccCheckCreate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCreateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"cloudhealth_perspective.acc_test_owner_tag", "name", "acc test owner tag"),
+				),
+			},
+		},
+	})
 }

--- a/cloudhealth/resource_cht_perspective.go
+++ b/cloudhealth/resource_cht_perspective.go
@@ -3,12 +3,13 @@ package cloudhealth
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
 	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 const apiUrl string = "https://chapi.cloudhealthtech.com/v1/perspective_schemas"
@@ -182,13 +183,21 @@ func resourceCHTPerspectiveCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	url := fmt.Sprintf("%s?api_key=%s", apiUrl, key)
+	log.Println("Posting to Cloudhealth: url %s data, %s", apiUrl, string(pj))
 	resp, err := http.Post(url, "application/json", bytes.NewReader(pj))
 	if err != nil {
-		return fmt.Errorf("Failed to create perspective because %s", err)
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		bodyStr := string(body)
+		log.Println("Response to Cloudhealth POST is:", bodyStr)
+		return fmt.Errorf("Failed to create perspective because %s, response %s", err, bodyStr)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		bodyStr := string(body)
+		log.Println("Response to Cloudhealth POST is:", bodyStr)
 		return fmt.Errorf("Failed to create perspective %s because got status code %d", d.Id(), resp.StatusCode)
 	}
 

--- a/vendor/github.com/hashicorp/logutils/LICENSE
+++ b/vendor/github.com/hashicorp/logutils/LICENSE
@@ -1,0 +1,354 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/logutils/README.md
+++ b/vendor/github.com/hashicorp/logutils/README.md
@@ -1,0 +1,36 @@
+# logutils
+
+logutils is a Go package that augments the standard library "log" package
+to make logging a bit more modern, without fragmenting the Go ecosystem
+with new logging packages.
+
+## The simplest thing that could possibly work
+
+Presumably your application already uses the default `log` package. To switch, you'll want your code to look like the following:
+
+```go
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/hashicorp/logutils"
+)
+
+func main() {
+	filter := &logutils.LevelFilter{
+		Levels: []logutils.LogLevel{"DEBUG", "WARN", "ERROR"},
+		MinLevel: logutils.LogLevel("WARN"),
+		Writer: os.Stderr,
+	}
+	log.SetOutput(filter)
+
+	log.Print("[DEBUG] Debugging") // this will not print
+	log.Print("[WARN] Warning") // this will
+	log.Print("[ERROR] Erring") // and so will this
+	log.Print("Message I haven't updated") // and so will this
+}
+```
+
+This logs to standard error exactly like go's standard logger. Any log messages you haven't converted to have a level will continue to print as before.

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -1,0 +1,81 @@
+// Package logutils augments the standard log package with levels.
+package logutils
+
+import (
+	"bytes"
+	"io"
+	"sync"
+)
+
+type LogLevel string
+
+// LevelFilter is an io.Writer that can be used with a logger that
+// will filter out log messages that aren't at least a certain level.
+//
+// Once the filter is in use somewhere, it is not safe to modify
+// the structure.
+type LevelFilter struct {
+	// Levels is the list of log levels, in increasing order of
+	// severity. Example might be: {"DEBUG", "WARN", "ERROR"}.
+	Levels []LogLevel
+
+	// MinLevel is the minimum level allowed through
+	MinLevel LogLevel
+
+	// The underlying io.Writer where log messages that pass the filter
+	// will be set.
+	Writer io.Writer
+
+	badLevels map[LogLevel]struct{}
+	once      sync.Once
+}
+
+// Check will check a given line if it would be included in the level
+// filter.
+func (f *LevelFilter) Check(line []byte) bool {
+	f.once.Do(f.init)
+
+	// Check for a log level
+	var level LogLevel
+	x := bytes.IndexByte(line, '[')
+	if x >= 0 {
+		y := bytes.IndexByte(line[x:], ']')
+		if y >= 0 {
+			level = LogLevel(line[x+1 : x+y])
+		}
+	}
+
+	_, ok := f.badLevels[level]
+	return !ok
+}
+
+func (f *LevelFilter) Write(p []byte) (n int, err error) {
+	// Note in general that io.Writer can receive any byte sequence
+	// to write, but the "log" package always guarantees that we only
+	// get a single line. We use that as a slight optimization within
+	// this method, assuming we're dealing with a single, complete line
+	// of log data.
+
+	if !f.Check(p) {
+		return len(p), nil
+	}
+
+	return f.Writer.Write(p)
+}
+
+// SetMinLevel is used to update the minimum log level
+func (f *LevelFilter) SetMinLevel(min LogLevel) {
+	f.MinLevel = min
+	f.init()
+}
+
+func (f *LevelFilter) init() {
+	badLevels := make(map[LogLevel]struct{})
+	for _, level := range f.Levels {
+		if level == f.MinLevel {
+			break
+		}
+		badLevels[level] = struct{}{}
+	}
+	f.badLevels = badLevels
+}

--- a/vendor/github.com/hashicorp/terraform/helper/config/decode.go
+++ b/vendor/github.com/hashicorp/terraform/helper/config/decode.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"github.com/mitchellh/mapstructure"
+)
+
+func Decode(target interface{}, raws ...interface{}) (*mapstructure.Metadata, error) {
+	var md mapstructure.Metadata
+	decoderConfig := &mapstructure.DecoderConfig{
+		Metadata:         &md,
+		Result:           target,
+		WeaklyTypedInput: true,
+	}
+
+	decoder, err := mapstructure.NewDecoder(decoderConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, raw := range raws {
+		err := decoder.Decode(raw)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &md, nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/config/validator.go
+++ b/vendor/github.com/hashicorp/terraform/helper/config/validator.go
@@ -1,0 +1,214 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform/flatmap"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Validator is a helper that helps you validate the configuration
+// of your resource, resource provider, etc.
+//
+// At the most basic level, set the Required and Optional lists to be
+// specifiers of keys that are required or optional. If a key shows up
+// that isn't in one of these two lists, then an error is generated.
+//
+// The "specifiers" allowed in this is a fairly rich syntax to help
+// describe the format of your configuration:
+//
+//   * Basic keys are just strings. For example: "foo" will match the
+//       "foo" key.
+//
+//   * Nested structure keys can be matched by doing
+//       "listener.*.foo". This will verify that there is at least one
+//       listener element that has the "foo" key set.
+//
+//   * The existence of a nested structure can be checked by simply
+//       doing "listener.*" which will verify that there is at least
+//       one element in the "listener" structure. This is NOT
+//       validating that "listener" is an array. It is validating
+//       that it is a nested structure in the configuration.
+//
+type Validator struct {
+	Required []string
+	Optional []string
+}
+
+func (v *Validator) Validate(
+	c *terraform.ResourceConfig) (ws []string, es []error) {
+	// Flatten the configuration so it is easier to reason about
+	flat := flatmap.Flatten(c.Raw)
+
+	keySet := make(map[string]validatorKey)
+	for i, vs := range [][]string{v.Required, v.Optional} {
+		req := i == 0
+		for _, k := range vs {
+			vk, err := newValidatorKey(k, req)
+			if err != nil {
+				es = append(es, err)
+				continue
+			}
+
+			keySet[k] = vk
+		}
+	}
+
+	purged := make([]string, 0)
+	for _, kv := range keySet {
+		p, w, e := kv.Validate(flat)
+		if len(w) > 0 {
+			ws = append(ws, w...)
+		}
+		if len(e) > 0 {
+			es = append(es, e...)
+		}
+
+		purged = append(purged, p...)
+	}
+
+	// Delete all the keys we processed in order to find
+	// the unknown keys.
+	for _, p := range purged {
+		delete(flat, p)
+	}
+
+	// The rest are unknown
+	for k, _ := range flat {
+		es = append(es, fmt.Errorf("Unknown configuration: %s", k))
+	}
+
+	return
+}
+
+type validatorKey interface {
+	// Validate validates the given configuration and returns viewed keys,
+	// warnings, and errors.
+	Validate(map[string]string) ([]string, []string, []error)
+}
+
+func newValidatorKey(k string, req bool) (validatorKey, error) {
+	var result validatorKey
+
+	parts := strings.Split(k, ".")
+	if len(parts) > 1 && parts[1] == "*" {
+		result = &nestedValidatorKey{
+			Parts:    parts,
+			Required: req,
+		}
+	} else {
+		result = &basicValidatorKey{
+			Key:      k,
+			Required: req,
+		}
+	}
+
+	return result, nil
+}
+
+// basicValidatorKey validates keys that are basic such as "foo"
+type basicValidatorKey struct {
+	Key      string
+	Required bool
+}
+
+func (v *basicValidatorKey) Validate(
+	m map[string]string) ([]string, []string, []error) {
+	for k, _ := range m {
+		// If we have the exact key its a match
+		if k == v.Key {
+			return []string{k}, nil, nil
+		}
+	}
+
+	if !v.Required {
+		return nil, nil, nil
+	}
+
+	return nil, nil, []error{fmt.Errorf(
+		"Key not found: %s", v.Key)}
+}
+
+type nestedValidatorKey struct {
+	Parts    []string
+	Required bool
+}
+
+func (v *nestedValidatorKey) validate(
+	m map[string]string,
+	prefix string,
+	offset int) ([]string, []string, []error) {
+	if offset >= len(v.Parts) {
+		// We're at the end. Look for a specific key.
+		v2 := &basicValidatorKey{Key: prefix, Required: v.Required}
+		return v2.Validate(m)
+	}
+
+	current := v.Parts[offset]
+
+	// If we're at offset 0, special case to start at the next one.
+	if offset == 0 {
+		return v.validate(m, current, offset+1)
+	}
+
+	// Determine if we're doing a "for all" or a specific key
+	if current != "*" {
+		// We're looking at a specific key, continue on.
+		return v.validate(m, prefix+"."+current, offset+1)
+	}
+
+	// We're doing a "for all", so we loop over.
+	countStr, ok := m[prefix+".#"]
+	if !ok {
+		if !v.Required {
+			// It wasn't required, so its no problem.
+			return nil, nil, nil
+		}
+
+		return nil, nil, []error{fmt.Errorf(
+			"Key not found: %s", prefix)}
+	}
+
+	count, err := strconv.ParseInt(countStr, 0, 0)
+	if err != nil {
+		// This shouldn't happen if flatmap works properly
+		panic("invalid flatmap array")
+	}
+
+	var e []error
+	var w []string
+	u := make([]string, 1, count+1)
+	u[0] = prefix + ".#"
+	for i := 0; i < int(count); i++ {
+		prefix := fmt.Sprintf("%s.%d", prefix, i)
+
+		// Mark that we saw this specific key
+		u = append(u, prefix)
+
+		// Mark all prefixes of this
+		for k, _ := range m {
+			if !strings.HasPrefix(k, prefix+".") {
+				continue
+			}
+			u = append(u, k)
+		}
+
+		// If we have more parts, then validate deeper
+		if offset+1 < len(v.Parts) {
+			u2, w2, e2 := v.validate(m, prefix, offset+1)
+
+			u = append(u, u2...)
+			w = append(w, w2...)
+			e = append(e, e2...)
+		}
+	}
+
+	return u, w, e
+}
+
+func (v *nestedValidatorKey) Validate(
+	m map[string]string) ([]string, []string, []error) {
+	return v.validate(m, "", 0)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform/helper/logging/logging.go
@@ -1,0 +1,100 @@
+package logging
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/hashicorp/logutils"
+)
+
+// These are the environmental variables that determine if we log, and if
+// we log whether or not the log should go to a file.
+const (
+	EnvLog     = "TF_LOG"      // Set to True
+	EnvLogFile = "TF_LOG_PATH" // Set to a file
+)
+
+var ValidLevels = []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"}
+
+// LogOutput determines where we should send logs (if anywhere) and the log level.
+func LogOutput() (logOutput io.Writer, err error) {
+	logOutput = ioutil.Discard
+
+	logLevel := LogLevel()
+	if logLevel == "" {
+		return
+	}
+
+	logOutput = os.Stderr
+	if logPath := os.Getenv(EnvLogFile); logPath != "" {
+		var err error
+		logOutput, err = os.OpenFile(logPath, syscall.O_CREAT|syscall.O_RDWR|syscall.O_APPEND, 0666)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// This was the default since the beginning
+	logOutput = &logutils.LevelFilter{
+		Levels:   ValidLevels,
+		MinLevel: logutils.LogLevel(logLevel),
+		Writer:   logOutput,
+	}
+
+	return
+}
+
+// SetOutput checks for a log destination with LogOutput, and calls
+// log.SetOutput with the result. If LogOutput returns nil, SetOutput uses
+// ioutil.Discard. Any error from LogOutout is fatal.
+func SetOutput() {
+	out, err := LogOutput()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if out == nil {
+		out = ioutil.Discard
+	}
+
+	log.SetOutput(out)
+}
+
+// LogLevel returns the current log level string based the environment vars
+func LogLevel() string {
+	envLevel := os.Getenv(EnvLog)
+	if envLevel == "" {
+		return ""
+	}
+
+	logLevel := "TRACE"
+	if isValidLogLevel(envLevel) {
+		// allow following for better ux: info, Info or INFO
+		logLevel = strings.ToUpper(envLevel)
+	} else {
+		log.Printf("[WARN] Invalid log level: %q. Defaulting to level: TRACE. Valid levels are: %+v",
+			envLevel, ValidLevels)
+	}
+
+	return logLevel
+}
+
+// IsDebugOrHigher returns whether or not the current log level is debug or trace
+func IsDebugOrHigher() bool {
+	level := string(LogLevel())
+	return level == "DEBUG" || level == "TRACE"
+}
+
+func isValidLogLevel(level string) bool {
+	for _, l := range ValidLevels {
+		if strings.ToUpper(level) == string(l) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/hashicorp/terraform/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform/helper/logging/transport.go
@@ -1,0 +1,53 @@
+package logging
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+type transport struct {
+	name      string
+	transport http.RoundTripper
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if IsDebugOrHigher() {
+		reqData, err := httputil.DumpRequestOut(req, true)
+		if err == nil {
+			log.Printf("[DEBUG] "+logReqMsg, t.name, string(reqData))
+		} else {
+			log.Printf("[ERROR] %s API Request error: %#v", t.name, err)
+		}
+	}
+
+	resp, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if IsDebugOrHigher() {
+		respData, err := httputil.DumpResponse(resp, true)
+		if err == nil {
+			log.Printf("[DEBUG] "+logRespMsg, t.name, string(respData))
+		} else {
+			log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
+		}
+	}
+
+	return resp, nil
+}
+
+func NewTransport(name string, t http.RoundTripper) *transport {
+	return &transport{name, t}
+}
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`

--- a/vendor/github.com/hashicorp/terraform/helper/resource/error.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/error.go
@@ -1,0 +1,79 @@
+package resource
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type NotFoundError struct {
+	LastError    error
+	LastRequest  interface{}
+	LastResponse interface{}
+	Message      string
+	Retries      int
+}
+
+func (e *NotFoundError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+
+	if e.Retries > 0 {
+		return fmt.Sprintf("couldn't find resource (%d retries)", e.Retries)
+	}
+
+	return "couldn't find resource"
+}
+
+// UnexpectedStateError is returned when Refresh returns a state that's neither in Target nor Pending
+type UnexpectedStateError struct {
+	LastError     error
+	State         string
+	ExpectedState []string
+}
+
+func (e *UnexpectedStateError) Error() string {
+	return fmt.Sprintf(
+		"unexpected state '%s', wanted target '%s'. last error: %s",
+		e.State,
+		strings.Join(e.ExpectedState, ", "),
+		e.LastError,
+	)
+}
+
+// TimeoutError is returned when WaitForState times out
+type TimeoutError struct {
+	LastError     error
+	LastState     string
+	Timeout       time.Duration
+	ExpectedState []string
+}
+
+func (e *TimeoutError) Error() string {
+	expectedState := "resource to be gone"
+	if len(e.ExpectedState) > 0 {
+		expectedState = fmt.Sprintf("state to become '%s'", strings.Join(e.ExpectedState, ", "))
+	}
+
+	extraInfo := make([]string, 0)
+	if e.LastState != "" {
+		extraInfo = append(extraInfo, fmt.Sprintf("last state: '%s'", e.LastState))
+	}
+	if e.Timeout > 0 {
+		extraInfo = append(extraInfo, fmt.Sprintf("timeout: %s", e.Timeout.String()))
+	}
+
+	suffix := ""
+	if len(extraInfo) > 0 {
+		suffix = fmt.Sprintf(" (%s)", strings.Join(extraInfo, ", "))
+	}
+
+	if e.LastError != nil {
+		return fmt.Sprintf("timeout while waiting for %s%s: %s",
+			expectedState, suffix, e.LastError)
+	}
+
+	return fmt.Sprintf("timeout while waiting for %s%s",
+		expectedState, suffix)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/resource/id.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/id.go
@@ -1,0 +1,39 @@
+package resource
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"sync"
+)
+
+const UniqueIdPrefix = `terraform-`
+
+// idCounter is a randomly seeded monotonic counter for generating ordered
+// unique ids.  It uses a big.Int so we can easily increment a long numeric
+// string.  The max possible hex value here with 12 random bytes is
+// "01000000000000000000000000", so there's no chance of rollover during
+// operation.
+var idMutex sync.Mutex
+var idCounter = big.NewInt(0).SetBytes(randomBytes(12))
+
+// Helper for a resource to generate a unique identifier w/ default prefix
+func UniqueId() string {
+	return PrefixedUniqueId(UniqueIdPrefix)
+}
+
+// Helper for a resource to generate a unique identifier w/ given prefix
+//
+// After the prefix, the ID consists of an incrementing 26 digit value (to match
+// previous timestamp output).
+func PrefixedUniqueId(prefix string) string {
+	idMutex.Lock()
+	defer idMutex.Unlock()
+	return fmt.Sprintf("%s%026x", prefix, idCounter.Add(idCounter, big.NewInt(1)))
+}
+
+func randomBytes(n int) []byte {
+	b := make([]byte, n)
+	rand.Read(b)
+	return b
+}

--- a/vendor/github.com/hashicorp/terraform/helper/resource/map.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/map.go
@@ -1,0 +1,140 @@
+package resource
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Map is a map of resources that are supported, and provides helpers for
+// more easily implementing a ResourceProvider.
+type Map struct {
+	Mapping map[string]Resource
+}
+
+func (m *Map) Validate(
+	t string, c *terraform.ResourceConfig) ([]string, []error) {
+	r, ok := m.Mapping[t]
+	if !ok {
+		return nil, []error{fmt.Errorf("Unknown resource type: %s", t)}
+	}
+
+	// If there is no validator set, then it is valid
+	if r.ConfigValidator == nil {
+		return nil, nil
+	}
+
+	return r.ConfigValidator.Validate(c)
+}
+
+// Apply performs a create or update depending on the diff, and calls
+// the proper function on the matching Resource.
+func (m *Map) Apply(
+	info *terraform.InstanceInfo,
+	s *terraform.InstanceState,
+	d *terraform.InstanceDiff,
+	meta interface{}) (*terraform.InstanceState, error) {
+	r, ok := m.Mapping[info.Type]
+	if !ok {
+		return nil, fmt.Errorf("Unknown resource type: %s", info.Type)
+	}
+
+	if d.Destroy || d.RequiresNew() {
+		if s.ID != "" {
+			// Destroy the resource if it is created
+			err := r.Destroy(s, meta)
+			if err != nil {
+				return s, err
+			}
+
+			s.ID = ""
+		}
+
+		// If we're only destroying, and not creating, then return now.
+		// Otherwise, we continue so that we can create a new resource.
+		if !d.RequiresNew() {
+			return nil, nil
+		}
+	}
+
+	var result *terraform.InstanceState
+	var err error
+	if s.ID == "" {
+		result, err = r.Create(s, d, meta)
+	} else {
+		if r.Update == nil {
+			return s, fmt.Errorf(
+				"Resource type '%s' doesn't support update",
+				info.Type)
+		}
+
+		result, err = r.Update(s, d, meta)
+	}
+	if result != nil {
+		if result.Attributes == nil {
+			result.Attributes = make(map[string]string)
+		}
+
+		result.Attributes["id"] = result.ID
+	}
+
+	return result, err
+}
+
+// Diff performs a diff on the proper resource type.
+func (m *Map) Diff(
+	info *terraform.InstanceInfo,
+	s *terraform.InstanceState,
+	c *terraform.ResourceConfig,
+	meta interface{}) (*terraform.InstanceDiff, error) {
+	r, ok := m.Mapping[info.Type]
+	if !ok {
+		return nil, fmt.Errorf("Unknown resource type: %s", info.Type)
+	}
+
+	return r.Diff(s, c, meta)
+}
+
+// Refresh performs a Refresh on the proper resource type.
+//
+// Refresh on the Resource won't be called if the state represents a
+// non-created resource (ID is blank).
+//
+// An error is returned if the resource isn't registered.
+func (m *Map) Refresh(
+	info *terraform.InstanceInfo,
+	s *terraform.InstanceState,
+	meta interface{}) (*terraform.InstanceState, error) {
+	// If the resource isn't created, don't refresh.
+	if s.ID == "" {
+		return s, nil
+	}
+
+	r, ok := m.Mapping[info.Type]
+	if !ok {
+		return nil, fmt.Errorf("Unknown resource type: %s", info.Type)
+	}
+
+	return r.Refresh(s, meta)
+}
+
+// Resources returns all the resources that are supported by this
+// resource map and can be used to satisfy the Resources method of
+// a ResourceProvider.
+func (m *Map) Resources() []terraform.ResourceType {
+	ks := make([]string, 0, len(m.Mapping))
+	for k, _ := range m.Mapping {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+
+	rs := make([]terraform.ResourceType, 0, len(m.Mapping))
+	for _, k := range ks {
+		rs = append(rs, terraform.ResourceType{
+			Name: k,
+		})
+	}
+
+	return rs
+}

--- a/vendor/github.com/hashicorp/terraform/helper/resource/resource.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/resource.go
@@ -1,0 +1,49 @@
+package resource
+
+import (
+	"github.com/hashicorp/terraform/helper/config"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+type Resource struct {
+	ConfigValidator *config.Validator
+	Create          CreateFunc
+	Destroy         DestroyFunc
+	Diff            DiffFunc
+	Refresh         RefreshFunc
+	Update          UpdateFunc
+}
+
+// CreateFunc is a function that creates a resource that didn't previously
+// exist.
+type CreateFunc func(
+	*terraform.InstanceState,
+	*terraform.InstanceDiff,
+	interface{}) (*terraform.InstanceState, error)
+
+// DestroyFunc is a function that destroys a resource that previously
+// exists using the state.
+type DestroyFunc func(
+	*terraform.InstanceState,
+	interface{}) error
+
+// DiffFunc is a function that performs a diff of a resource.
+type DiffFunc func(
+	*terraform.InstanceState,
+	*terraform.ResourceConfig,
+	interface{}) (*terraform.InstanceDiff, error)
+
+// RefreshFunc is a function that performs a refresh of a specific type
+// of resource.
+type RefreshFunc func(
+	*terraform.InstanceState,
+	interface{}) (*terraform.InstanceState, error)
+
+// UpdateFunc is a function that is called to update a resource that
+// previously existed. The difference between this and CreateFunc is that
+// the diff is guaranteed to only contain attributes that don't require
+// a new resource.
+type UpdateFunc func(
+	*terraform.InstanceState,
+	*terraform.InstanceDiff,
+	interface{}) (*terraform.InstanceState, error)

--- a/vendor/github.com/hashicorp/terraform/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/state.go
@@ -1,0 +1,191 @@
+package resource
+
+import (
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+// StateRefreshFunc is a function type used for StateChangeConf that is
+// responsible for refreshing the item being watched for a state change.
+//
+// It returns three results. `result` is any object that will be returned
+// as the final object after waiting for state change. This allows you to
+// return the final updated object, for example an EC2 instance after refreshing
+// it.
+//
+// `state` is the latest state of that object. And `err` is any error that
+// may have happened while refreshing the state.
+type StateRefreshFunc func() (result interface{}, state string, err error)
+
+// StateChangeConf is the configuration struct used for `WaitForState`.
+type StateChangeConf struct {
+	Delay          time.Duration    // Wait this time before starting checks
+	Pending        []string         // States that are "allowed" and will continue trying
+	Refresh        StateRefreshFunc // Refreshes the current state
+	Target         []string         // Target state
+	Timeout        time.Duration    // The amount of time to wait before timeout
+	MinTimeout     time.Duration    // Smallest time to wait before refreshes
+	PollInterval   time.Duration    // Override MinTimeout/backoff and only poll this often
+	NotFoundChecks int              // Number of times to allow not found
+
+	// This is to work around inconsistent APIs
+	ContinuousTargetOccurence int // Number of times the Target state has to occur continuously
+}
+
+// WaitForState watches an object and waits for it to achieve the state
+// specified in the configuration using the specified Refresh() func,
+// waiting the number of seconds specified in the timeout configuration.
+//
+// If the Refresh function returns a error, exit immediately with that error.
+//
+// If the Refresh function returns a state other than the Target state or one
+// listed in Pending, return immediately with an error.
+//
+// If the Timeout is exceeded before reaching the Target state, return an
+// error.
+//
+// Otherwise, result the result of the first call to the Refresh function to
+// reach the target state.
+func (conf *StateChangeConf) WaitForState() (interface{}, error) {
+	log.Printf("[DEBUG] Waiting for state to become: %s", conf.Target)
+
+	notfoundTick := 0
+	targetOccurence := 0
+
+	// Set a default for times to check for not found
+	if conf.NotFoundChecks == 0 {
+		conf.NotFoundChecks = 20
+	}
+
+	if conf.ContinuousTargetOccurence == 0 {
+		conf.ContinuousTargetOccurence = 1
+	}
+
+	// We can't safely read the result values if we timeout, so store them in
+	// an atomic.Value
+	type Result struct {
+		Result interface{}
+		State  string
+		Error  error
+	}
+	var lastResult atomic.Value
+	lastResult.Store(Result{})
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+
+		// Wait for the delay
+		time.Sleep(conf.Delay)
+
+		wait := 100 * time.Millisecond
+
+		for {
+			res, currentState, err := conf.Refresh()
+			result := Result{
+				Result: res,
+				State:  currentState,
+				Error:  err,
+			}
+			lastResult.Store(result)
+
+			if err != nil {
+				return
+			}
+
+			// If we're waiting for the absence of a thing, then return
+			if res == nil && len(conf.Target) == 0 {
+				targetOccurence += 1
+				if conf.ContinuousTargetOccurence == targetOccurence {
+					return
+				} else {
+					continue
+				}
+			}
+
+			if res == nil {
+				// If we didn't find the resource, check if we have been
+				// not finding it for awhile, and if so, report an error.
+				notfoundTick += 1
+				if notfoundTick > conf.NotFoundChecks {
+					result.Error = &NotFoundError{
+						LastError: err,
+						Retries:   notfoundTick,
+					}
+					lastResult.Store(result)
+					return
+				}
+			} else {
+				// Reset the counter for when a resource isn't found
+				notfoundTick = 0
+				found := false
+
+				for _, allowed := range conf.Target {
+					if currentState == allowed {
+						found = true
+						targetOccurence += 1
+						if conf.ContinuousTargetOccurence == targetOccurence {
+							return
+						} else {
+							continue
+						}
+					}
+				}
+
+				for _, allowed := range conf.Pending {
+					if currentState == allowed {
+						found = true
+						targetOccurence = 0
+						break
+					}
+				}
+
+				if !found {
+					result.Error = &UnexpectedStateError{
+						LastError:     err,
+						State:         result.State,
+						ExpectedState: conf.Target,
+					}
+					lastResult.Store(result)
+					return
+				}
+			}
+
+			// If a poll interval has been specified, choose that interval.
+			// Otherwise bound the default value.
+			if conf.PollInterval > 0 && conf.PollInterval < 180*time.Second {
+				wait = conf.PollInterval
+			} else {
+				if wait < conf.MinTimeout {
+					wait = conf.MinTimeout
+				} else if wait > 10*time.Second {
+					wait = 10 * time.Second
+				}
+			}
+
+			log.Printf("[TRACE] Waiting %s before next try", wait)
+			time.Sleep(wait)
+
+			// Wait between refreshes using exponential backoff, except when
+			// waiting for the target state to reoccur.
+			if targetOccurence == 0 {
+				wait *= 2
+			}
+		}
+	}()
+
+	select {
+	case <-doneCh:
+		r := lastResult.Load().(Result)
+		return r.Result, r.Error
+	case <-time.After(conf.Timeout):
+		r := lastResult.Load().(Result)
+		return nil, &TimeoutError{
+			LastError:     r.Error,
+			LastState:     r.State,
+			Timeout:       conf.Timeout,
+			ExpectedState: conf.Target,
+		}
+	}
+}

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
@@ -1,0 +1,741 @@
+package resource
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/go-getter"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/helper/logging"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const TestEnvVar = "TF_ACC"
+
+// TestCheckFunc is the callback type used with acceptance tests to check
+// the state of a resource. The state passed in is the latest state known,
+// or in the case of being after a destroy, it is the last known state when
+// it was created.
+type TestCheckFunc func(*terraform.State) error
+
+// ImportStateCheckFunc is the check function for ImportState tests
+type ImportStateCheckFunc func([]*terraform.InstanceState) error
+
+// TestCase is a single acceptance test case used to test the apply/destroy
+// lifecycle of a resource in a specific configuration.
+//
+// When the destroy plan is executed, the config from the last TestStep
+// is used to plan it.
+type TestCase struct {
+	// IsUnitTest allows a test to run regardless of the TF_ACC
+	// environment variable. This should be used with care - only for
+	// fast tests on local resources (e.g. remote state with a local
+	// backend) but can be used to increase confidence in correct
+	// operation of Terraform without waiting for a full acctest run.
+	IsUnitTest bool
+
+	// PreCheck, if non-nil, will be called before any test steps are
+	// executed. It will only be executed in the case that the steps
+	// would run, so it can be used for some validation before running
+	// acceptance tests, such as verifying that keys are setup.
+	PreCheck func()
+
+	// Providers is the ResourceProvider that will be under test.
+	//
+	// Alternately, ProviderFactories can be specified for the providers
+	// that are valid. This takes priority over Providers.
+	//
+	// The end effect of each is the same: specifying the providers that
+	// are used within the tests.
+	Providers         map[string]terraform.ResourceProvider
+	ProviderFactories map[string]terraform.ResourceProviderFactory
+
+	// PreventPostDestroyRefresh can be set to true for cases where data sources
+	// are tested alongside real resources
+	PreventPostDestroyRefresh bool
+
+	// CheckDestroy is called after the resource is finally destroyed
+	// to allow the tester to test that the resource is truly gone.
+	CheckDestroy TestCheckFunc
+
+	// Steps are the apply sequences done within the context of the
+	// same state. Each step can have its own check to verify correctness.
+	Steps []TestStep
+
+	// The settings below control the "ID-only refresh test." This is
+	// an enabled-by-default test that tests that a refresh can be
+	// refreshed with only an ID to result in the same attributes.
+	// This validates completeness of Refresh.
+	//
+	// IDRefreshName is the name of the resource to check. This will
+	// default to the first non-nil primary resource in the state.
+	//
+	// IDRefreshIgnore is a list of configuration keys that will be ignored.
+	IDRefreshName   string
+	IDRefreshIgnore []string
+}
+
+// TestStep is a single apply sequence of a test, done within the
+// context of a state.
+//
+// Multiple TestSteps can be sequenced in a Test to allow testing
+// potentially complex update logic. In general, simply create/destroy
+// tests will only need one step.
+type TestStep struct {
+	// ResourceName should be set to the name of the resource
+	// that is being tested. Example: "aws_instance.foo". Various test
+	// modes use this to auto-detect state information.
+	//
+	// This is only required if the test mode settings below say it is
+	// for the mode you're using.
+	ResourceName string
+
+	// PreConfig is called before the Config is applied to perform any per-step
+	// setup that needs to happen. This is called regardless of "test mode"
+	// below.
+	PreConfig func()
+
+	//---------------------------------------------------------------
+	// Test modes. One of the following groups of settings must be
+	// set to determine what the test step will do. Ideally we would've
+	// used Go interfaces here but there are now hundreds of tests we don't
+	// want to re-type so instead we just determine which step logic
+	// to run based on what settings below are set.
+	//---------------------------------------------------------------
+
+	//---------------------------------------------------------------
+	// Plan, Apply testing
+	//---------------------------------------------------------------
+
+	// Config a string of the configuration to give to Terraform. If this
+	// is set, then the TestCase will execute this step with the same logic
+	// as a `terraform apply`.
+	Config string
+
+	// Check is called after the Config is applied. Use this step to
+	// make your own API calls to check the status of things, and to
+	// inspect the format of the ResourceState itself.
+	//
+	// If an error is returned, the test will fail. In this case, a
+	// destroy plan will still be attempted.
+	//
+	// If this is nil, no check is done on this step.
+	Check TestCheckFunc
+
+	// Destroy will create a destroy plan if set to true.
+	Destroy bool
+
+	// ExpectNonEmptyPlan can be set to true for specific types of tests that are
+	// looking to verify that a diff occurs
+	ExpectNonEmptyPlan bool
+
+	// ExpectError allows the construction of test cases that we expect to fail
+	// with an error. The specified regexp must match against the error for the
+	// test to pass.
+	ExpectError *regexp.Regexp
+
+	// PreventPostDestroyRefresh can be set to true for cases where data sources
+	// are tested alongside real resources
+	PreventPostDestroyRefresh bool
+
+	//---------------------------------------------------------------
+	// ImportState testing
+	//---------------------------------------------------------------
+
+	// ImportState, if true, will test the functionality of ImportState
+	// by importing the resource with ResourceName (must be set) and the
+	// ID of that resource.
+	ImportState bool
+
+	// ImportStateId is the ID to perform an ImportState operation with.
+	// This is optional. If it isn't set, then the resource ID is automatically
+	// determined by inspecting the state for ResourceName's ID.
+	ImportStateId string
+
+	// ImportStateCheck checks the results of ImportState. It should be
+	// used to verify that the resulting value of ImportState has the
+	// proper resources, IDs, and attributes.
+	ImportStateCheck ImportStateCheckFunc
+
+	// ImportStateVerify, if true, will also check that the state values
+	// that are finally put into the state after import match for all the
+	// IDs returned by the Import.
+	//
+	// ImportStateVerifyIgnore are fields that should not be verified to
+	// be equal. These can be set to ephemeral fields or fields that can't
+	// be refreshed and don't matter.
+	ImportStateVerify       bool
+	ImportStateVerifyIgnore []string
+}
+
+// Test performs an acceptance test on a resource.
+//
+// Tests are not run unless an environmental variable "TF_ACC" is
+// set to some non-empty value. This is to avoid test cases surprising
+// a user by creating real resources.
+//
+// Tests will fail unless the verbose flag (`go test -v`, or explicitly
+// the "-test.v" flag) is set. Because some acceptance tests take quite
+// long, we require the verbose flag so users are able to see progress
+// output.
+func Test(t TestT, c TestCase) {
+	// We only run acceptance tests if an env var is set because they're
+	// slow and generally require some outside configuration. You can opt out
+	// of this with OverrideEnvVar on individual TestCases.
+	if os.Getenv(TestEnvVar) == "" && !c.IsUnitTest {
+		t.Skip(fmt.Sprintf(
+			"Acceptance tests skipped unless env '%s' set",
+			TestEnvVar))
+		return
+	}
+
+	logWriter, err := logging.LogOutput()
+	if err != nil {
+		t.Error(fmt.Errorf("error setting up logging: %s", err))
+	}
+	log.SetOutput(logWriter)
+
+	// We require verbose mode so that the user knows what is going on.
+	if !testTesting && !testing.Verbose() && !c.IsUnitTest {
+		t.Fatal("Acceptance tests must be run with the -v flag on tests")
+		return
+	}
+
+	// Run the PreCheck if we have it
+	if c.PreCheck != nil {
+		c.PreCheck()
+	}
+
+	// Build our context options that we can
+	ctxProviders := c.ProviderFactories
+	if ctxProviders == nil {
+		ctxProviders = make(map[string]terraform.ResourceProviderFactory)
+		for k, p := range c.Providers {
+			ctxProviders[k] = terraform.ResourceProviderFactoryFixed(p)
+		}
+	}
+	opts := terraform.ContextOpts{Providers: ctxProviders}
+
+	// A single state variable to track the lifecycle, starting with no state
+	var state *terraform.State
+
+	// Go through each step and run it
+	var idRefreshCheck *terraform.ResourceState
+	idRefresh := c.IDRefreshName != ""
+	errored := false
+	for i, step := range c.Steps {
+		var err error
+		log.Printf("[WARN] Test: Executing step %d", i)
+
+		// Determine the test mode to execute
+		if step.Config != "" {
+			state, err = testStepConfig(opts, state, step)
+		} else if step.ImportState {
+			state, err = testStepImportState(opts, state, step)
+		} else {
+			err = fmt.Errorf(
+				"unknown test mode for step. Please see TestStep docs\n\n%#v",
+				step)
+		}
+
+		// If there was an error, exit
+		if err != nil {
+			// Perhaps we expected an error? Check if it matches
+			if step.ExpectError != nil {
+				if !step.ExpectError.MatchString(err.Error()) {
+					errored = true
+					t.Error(fmt.Sprintf(
+						"Step %d, expected error:\n\n%s\n\nTo match:\n\n%s\n\n",
+						i, err, step.ExpectError))
+					break
+				}
+			} else {
+				errored = true
+				t.Error(fmt.Sprintf(
+					"Step %d error: %s", i, err))
+				break
+			}
+		}
+
+		// If we've never checked an id-only refresh and our state isn't
+		// empty, find the first resource and test it.
+		if idRefresh && idRefreshCheck == nil && !state.Empty() {
+			// Find the first non-nil resource in the state
+			for _, m := range state.Modules {
+				if len(m.Resources) > 0 {
+					if v, ok := m.Resources[c.IDRefreshName]; ok {
+						idRefreshCheck = v
+					}
+
+					break
+				}
+			}
+
+			// If we have an instance to check for refreshes, do it
+			// immediately. We do it in the middle of another test
+			// because it shouldn't affect the overall state (refresh
+			// is read-only semantically) and we want to fail early if
+			// this fails. If refresh isn't read-only, then this will have
+			// caught a different bug.
+			if idRefreshCheck != nil {
+				log.Printf(
+					"[WARN] Test: Running ID-only refresh check on %s",
+					idRefreshCheck.Primary.ID)
+				if err := testIDOnlyRefresh(c, opts, step, idRefreshCheck); err != nil {
+					log.Printf("[ERROR] Test: ID-only test failed: %s", err)
+					t.Error(fmt.Sprintf(
+						"[ERROR] Test: ID-only test failed: %s", err))
+					break
+				}
+			}
+		}
+	}
+
+	// If we never checked an id-only refresh, it is a failure.
+	if idRefresh {
+		if !errored && len(c.Steps) > 0 && idRefreshCheck == nil {
+			t.Error("ID-only refresh check never ran.")
+		}
+	}
+
+	// If we have a state, then run the destroy
+	if state != nil {
+		lastStep := c.Steps[len(c.Steps)-1]
+		destroyStep := TestStep{
+			Config:                    lastStep.Config,
+			Check:                     c.CheckDestroy,
+			Destroy:                   true,
+			PreventPostDestroyRefresh: c.PreventPostDestroyRefresh,
+		}
+
+		log.Printf("[WARN] Test: Executing destroy step")
+		state, err := testStep(opts, state, destroyStep)
+		if err != nil {
+			t.Error(fmt.Sprintf(
+				"Error destroying resource! WARNING: Dangling resources\n"+
+					"may exist. The full state and error is shown below.\n\n"+
+					"Error: %s\n\nState: %s",
+				err,
+				state))
+		}
+	} else {
+		log.Printf("[WARN] Skipping destroy test since there is no state.")
+	}
+}
+
+// UnitTest is a helper to force the acceptance testing harness to run in the
+// normal unit test suite. This should only be used for resource that don't
+// have any external dependencies.
+func UnitTest(t TestT, c TestCase) {
+	c.IsUnitTest = true
+	Test(t, c)
+}
+
+func testIDOnlyRefresh(c TestCase, opts terraform.ContextOpts, step TestStep, r *terraform.ResourceState) error {
+	// TODO: We guard by this right now so master doesn't explode. We
+	// need to remove this eventually to make this part of the normal tests.
+	if os.Getenv("TF_ACC_IDONLY") == "" {
+		return nil
+	}
+
+	name := fmt.Sprintf("%s.foo", r.Type)
+
+	// Build the state. The state is just the resource with an ID. There
+	// are no attributes. We only set what is needed to perform a refresh.
+	state := terraform.NewState()
+	state.RootModule().Resources[name] = &terraform.ResourceState{
+		Type: r.Type,
+		Primary: &terraform.InstanceState{
+			ID: r.Primary.ID,
+		},
+	}
+
+	// Create the config module. We use the full config because Refresh
+	// doesn't have access to it and we may need things like provider
+	// configurations. The initial implementation of id-only checks used
+	// an empty config module, but that caused the aforementioned problems.
+	mod, err := testModule(opts, step)
+	if err != nil {
+		return err
+	}
+
+	// Initialize the context
+	opts.Module = mod
+	opts.State = state
+	ctx, err := terraform.NewContext(&opts)
+	if err != nil {
+		return err
+	}
+	if ws, es := ctx.Validate(); len(ws) > 0 || len(es) > 0 {
+		if len(es) > 0 {
+			estrs := make([]string, len(es))
+			for i, e := range es {
+				estrs[i] = e.Error()
+			}
+			return fmt.Errorf(
+				"Configuration is invalid.\n\nWarnings: %#v\n\nErrors: %#v",
+				ws, estrs)
+		}
+
+		log.Printf("[WARN] Config warnings: %#v", ws)
+	}
+
+	// Refresh!
+	state, err = ctx.Refresh()
+	if err != nil {
+		return fmt.Errorf("Error refreshing: %s", err)
+	}
+
+	// Verify attribute equivalence.
+	actualR := state.RootModule().Resources[name]
+	if actualR == nil {
+		return fmt.Errorf("Resource gone!")
+	}
+	if actualR.Primary == nil {
+		return fmt.Errorf("Resource has no primary instance")
+	}
+	actual := actualR.Primary.Attributes
+	expected := r.Primary.Attributes
+	// Remove fields we're ignoring
+	for _, v := range c.IDRefreshIgnore {
+		for k, _ := range actual {
+			if strings.HasPrefix(k, v) {
+				delete(actual, k)
+			}
+		}
+		for k, _ := range expected {
+			if strings.HasPrefix(k, v) {
+				delete(expected, k)
+			}
+		}
+	}
+
+	if !reflect.DeepEqual(actual, expected) {
+		// Determine only the different attributes
+		for k, v := range expected {
+			if av, ok := actual[k]; ok && v == av {
+				delete(expected, k)
+				delete(actual, k)
+			}
+		}
+
+		spewConf := spew.NewDefaultConfig()
+		spewConf.SortKeys = true
+		return fmt.Errorf(
+			"Attributes not equivalent. Difference is shown below. Top is actual, bottom is expected."+
+				"\n\n%s\n\n%s",
+			spewConf.Sdump(actual), spewConf.Sdump(expected))
+	}
+
+	return nil
+}
+
+func testModule(
+	opts terraform.ContextOpts,
+	step TestStep) (*module.Tree, error) {
+	if step.PreConfig != nil {
+		step.PreConfig()
+	}
+
+	cfgPath, err := ioutil.TempDir("", "tf-test")
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error creating temporary directory for config: %s", err)
+	}
+	defer os.RemoveAll(cfgPath)
+
+	// Write the configuration
+	cfgF, err := os.Create(filepath.Join(cfgPath, "main.tf"))
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error creating temporary file for config: %s", err)
+	}
+
+	_, err = io.Copy(cfgF, strings.NewReader(step.Config))
+	cfgF.Close()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error creating temporary file for config: %s", err)
+	}
+
+	// Parse the configuration
+	mod, err := module.NewTreeModule("", cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Error loading configuration: %s", err)
+	}
+
+	// Load the modules
+	modStorage := &getter.FolderStorage{
+		StorageDir: filepath.Join(cfgPath, ".tfmodules"),
+	}
+	err = mod.Load(modStorage, module.GetModeGet)
+	if err != nil {
+		return nil, fmt.Errorf("Error downloading modules: %s", err)
+	}
+
+	return mod, nil
+}
+
+func testResource(c TestStep, state *terraform.State) (*terraform.ResourceState, error) {
+	if c.ResourceName == "" {
+		return nil, fmt.Errorf("ResourceName must be set in TestStep")
+	}
+
+	for _, m := range state.Modules {
+		if len(m.Resources) > 0 {
+			if v, ok := m.Resources[c.ResourceName]; ok {
+				return v, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"Resource specified by ResourceName couldn't be found: %s", c.ResourceName)
+}
+
+// ComposeTestCheckFunc lets you compose multiple TestCheckFuncs into
+// a single TestCheckFunc.
+//
+// As a user testing their provider, this lets you decompose your checks
+// into smaller pieces more easily.
+func ComposeTestCheckFunc(fs ...TestCheckFunc) TestCheckFunc {
+	return func(s *terraform.State) error {
+		for i, f := range fs {
+			if err := f(s); err != nil {
+				return fmt.Errorf("Check %d/%d error: %s", i+1, len(fs), err)
+			}
+		}
+
+		return nil
+	}
+}
+
+// ComposeAggregateTestCheckFunc lets you compose multiple TestCheckFuncs into
+// a single TestCheckFunc.
+//
+// As a user testing their provider, this lets you decompose your checks
+// into smaller pieces more easily.
+//
+// Unlike ComposeTestCheckFunc, ComposeAggergateTestCheckFunc runs _all_ of the
+// TestCheckFuncs and aggregates failures.
+func ComposeAggregateTestCheckFunc(fs ...TestCheckFunc) TestCheckFunc {
+	return func(s *terraform.State) error {
+		var result *multierror.Error
+
+		for i, f := range fs {
+			if err := f(s); err != nil {
+				result = multierror.Append(result, fmt.Errorf("Check %d/%d error: %s", i+1, len(fs), err))
+			}
+		}
+
+		return result.ErrorOrNil()
+	}
+}
+
+// TestCheckResourceAttrSet is a TestCheckFunc which ensures a value
+// exists in state for the given name/key combination. It is useful when
+// testing that computed values were set, when it is not possible to
+// know ahead of time what the values will be.
+func TestCheckResourceAttrSet(name, key string) TestCheckFunc {
+	return func(s *terraform.State) error {
+		is, err := primaryInstanceState(s, name)
+		if err != nil {
+			return err
+		}
+
+		if val, ok := is.Attributes[key]; ok && val != "" {
+			return nil
+		}
+
+		return fmt.Errorf("%s: Attribute '%s' expected to be set", name, key)
+	}
+}
+
+// TestCheckResourceAttr is a TestCheckFunc which validates
+// the value in state for the given name/key combination.
+func TestCheckResourceAttr(name, key, value string) TestCheckFunc {
+	return func(s *terraform.State) error {
+		is, err := primaryInstanceState(s, name)
+		if err != nil {
+			return err
+		}
+
+		if v, ok := is.Attributes[key]; !ok || v != value {
+			if !ok {
+				return fmt.Errorf("%s: Attribute '%s' not found", name, key)
+			}
+
+			return fmt.Errorf(
+				"%s: Attribute '%s' expected %#v, got %#v",
+				name,
+				key,
+				value,
+				v)
+		}
+
+		return nil
+	}
+}
+
+// TestCheckNoResourceAttr is a TestCheckFunc which ensures that
+// NO value exists in state for the given name/key combination.
+func TestCheckNoResourceAttr(name, key string) TestCheckFunc {
+	return func(s *terraform.State) error {
+		is, err := primaryInstanceState(s, name)
+		if err != nil {
+			return err
+		}
+
+		if _, ok := is.Attributes[key]; ok {
+			return fmt.Errorf("%s: Attribute '%s' found when not expected", name, key)
+		}
+
+		return nil
+	}
+}
+
+// TestMatchResourceAttr is a TestCheckFunc which checks that the value
+// in state for the given name/key combination matches the given regex.
+func TestMatchResourceAttr(name, key string, r *regexp.Regexp) TestCheckFunc {
+	return func(s *terraform.State) error {
+		is, err := primaryInstanceState(s, name)
+		if err != nil {
+			return err
+		}
+
+		if !r.MatchString(is.Attributes[key]) {
+			return fmt.Errorf(
+				"%s: Attribute '%s' didn't match %q, got %#v",
+				name,
+				key,
+				r.String(),
+				is.Attributes[key])
+		}
+
+		return nil
+	}
+}
+
+// TestCheckResourceAttrPtr is like TestCheckResourceAttr except the
+// value is a pointer so that it can be updated while the test is running.
+// It will only be dereferenced at the point this step is run.
+func TestCheckResourceAttrPtr(name string, key string, value *string) TestCheckFunc {
+	return func(s *terraform.State) error {
+		return TestCheckResourceAttr(name, key, *value)(s)
+	}
+}
+
+// TestCheckResourceAttrPair is a TestCheckFunc which validates that the values
+// in state for a pair of name/key combinations are equal.
+func TestCheckResourceAttrPair(nameFirst, keyFirst, nameSecond, keySecond string) TestCheckFunc {
+	return func(s *terraform.State) error {
+		isFirst, err := primaryInstanceState(s, nameFirst)
+		if err != nil {
+			return err
+		}
+		vFirst, ok := isFirst.Attributes[keyFirst]
+		if !ok {
+			return fmt.Errorf("%s: Attribute '%s' not found", nameFirst, keyFirst)
+		}
+
+		isSecond, err := primaryInstanceState(s, nameSecond)
+		if err != nil {
+			return err
+		}
+		vSecond, ok := isSecond.Attributes[keySecond]
+		if !ok {
+			return fmt.Errorf("%s: Attribute '%s' not found", nameSecond, keySecond)
+		}
+
+		if vFirst != vSecond {
+			return fmt.Errorf(
+				"%s: Attribute '%s' expected %#v, got %#v",
+				nameFirst,
+				keyFirst,
+				vSecond,
+				vFirst)
+		}
+
+		return nil
+	}
+}
+
+// TestCheckOutput checks an output in the Terraform configuration
+func TestCheckOutput(name, value string) TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Outputs[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if rs.Value != value {
+			return fmt.Errorf(
+				"Output '%s': expected %#v, got %#v",
+				name,
+				value,
+				rs)
+		}
+
+		return nil
+	}
+}
+
+func TestMatchOutput(name string, r *regexp.Regexp) TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Outputs[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		if !r.MatchString(rs.Value.(string)) {
+			return fmt.Errorf(
+				"Output '%s': %#v didn't match %q",
+				name,
+				rs,
+				r.String())
+		}
+
+		return nil
+	}
+}
+
+// TestT is the interface used to handle the test lifecycle of a test.
+//
+// Users should just use a *testing.T object, which implements this.
+type TestT interface {
+	Error(args ...interface{})
+	Fatal(args ...interface{})
+	Skip(args ...interface{})
+}
+
+// This is set to true by unit tests to alter some behavior
+var testTesting = false
+
+// primaryInstanceState returns the primary instance state for the given resource name.
+func primaryInstanceState(s *terraform.State, name string) (*terraform.InstanceState, error) {
+	ms := s.RootModule()
+	rs, ok := ms.Resources[name]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s", name)
+	}
+
+	is := rs.Primary
+	if is == nil {
+		return nil, fmt.Errorf("No primary instance: %s", name)
+	}
+
+	return is, nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go
@@ -1,0 +1,156 @@
+package resource
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// testStepConfig runs a config-mode test step
+func testStepConfig(
+	opts terraform.ContextOpts,
+	state *terraform.State,
+	step TestStep) (*terraform.State, error) {
+	return testStep(opts, state, step)
+}
+
+func testStep(
+	opts terraform.ContextOpts,
+	state *terraform.State,
+	step TestStep) (*terraform.State, error) {
+	mod, err := testModule(opts, step)
+	if err != nil {
+		return state, err
+	}
+
+	// Build the context
+	opts.Module = mod
+	opts.State = state
+	opts.Destroy = step.Destroy
+	ctx, err := terraform.NewContext(&opts)
+	if err != nil {
+		return state, fmt.Errorf("Error initializing context: %s", err)
+	}
+	if ws, es := ctx.Validate(); len(ws) > 0 || len(es) > 0 {
+		if len(es) > 0 {
+			estrs := make([]string, len(es))
+			for i, e := range es {
+				estrs[i] = e.Error()
+			}
+			return state, fmt.Errorf(
+				"Configuration is invalid.\n\nWarnings: %#v\n\nErrors: %#v",
+				ws, estrs)
+		}
+		log.Printf("[WARN] Config warnings: %#v", ws)
+	}
+
+	// Refresh!
+	state, err = ctx.Refresh()
+	if err != nil {
+		return state, fmt.Errorf(
+			"Error refreshing: %s", err)
+	}
+
+	// Plan!
+	if p, err := ctx.Plan(); err != nil {
+		return state, fmt.Errorf(
+			"Error planning: %s", err)
+	} else {
+		log.Printf("[WARN] Test: Step plan: %s", p)
+	}
+
+	// We need to keep a copy of the state prior to destroying
+	// such that destroy steps can verify their behaviour in the check
+	// function
+	stateBeforeApplication := state.DeepCopy()
+
+	// Apply!
+	state, err = ctx.Apply()
+	if err != nil {
+		return state, fmt.Errorf("Error applying: %s", err)
+	}
+
+	// Check! Excitement!
+	if step.Check != nil {
+		if step.Destroy {
+			if err := step.Check(stateBeforeApplication); err != nil {
+				return state, fmt.Errorf("Check failed: %s", err)
+			}
+		} else {
+			if err := step.Check(state); err != nil {
+				return state, fmt.Errorf("Check failed: %s", err)
+			}
+		}
+	}
+
+	// Now, verify that Plan is now empty and we don't have a perpetual diff issue
+	// We do this with TWO plans. One without a refresh.
+	var p *terraform.Plan
+	if p, err = ctx.Plan(); err != nil {
+		return state, fmt.Errorf("Error on follow-up plan: %s", err)
+	}
+	if p.Diff != nil && !p.Diff.Empty() {
+		if step.ExpectNonEmptyPlan {
+			log.Printf("[INFO] Got non-empty plan, as expected:\n\n%s", p)
+		} else {
+			return state, fmt.Errorf(
+				"After applying this step, the plan was not empty:\n\n%s", p)
+		}
+	}
+
+	// And another after a Refresh.
+	if !step.Destroy || (step.Destroy && !step.PreventPostDestroyRefresh) {
+		state, err = ctx.Refresh()
+		if err != nil {
+			return state, fmt.Errorf(
+				"Error on follow-up refresh: %s", err)
+		}
+	}
+	if p, err = ctx.Plan(); err != nil {
+		return state, fmt.Errorf("Error on second follow-up plan: %s", err)
+	}
+	empty := p.Diff == nil || p.Diff.Empty()
+
+	// Data resources are tricky because they legitimately get instantiated
+	// during refresh so that they will be already populated during the
+	// plan walk. Because of this, if we have any data resources in the
+	// config we'll end up wanting to destroy them again here. This is
+	// acceptable and expected, and we'll treat it as "empty" for the
+	// sake of this testing.
+	if step.Destroy {
+		empty = true
+
+		for _, moduleDiff := range p.Diff.Modules {
+			for k, instanceDiff := range moduleDiff.Resources {
+				if !strings.HasPrefix(k, "data.") {
+					empty = false
+					break
+				}
+
+				if !instanceDiff.Destroy {
+					empty = false
+				}
+			}
+		}
+	}
+
+	if !empty {
+		if step.ExpectNonEmptyPlan {
+			log.Printf("[INFO] Got non-empty plan, as expected:\n\n%s", p)
+		} else {
+			return state, fmt.Errorf(
+				"After applying this step and refreshing, "+
+					"the plan was not empty:\n\n%s", p)
+		}
+	}
+
+	// Made it here, but expected a non-empty plan, fail!
+	if step.ExpectNonEmptyPlan && (p.Diff == nil || p.Diff.Empty()) {
+		return state, fmt.Errorf("Expected a non-empty plan, but got an empty plan!")
+	}
+
+	// Made it here? Good job test step!
+	return state, nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing_import_state.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing_import_state.go
@@ -1,0 +1,137 @@
+package resource
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// testStepImportState runs an imort state test step
+func testStepImportState(
+	opts terraform.ContextOpts,
+	state *terraform.State,
+	step TestStep) (*terraform.State, error) {
+	// Determine the ID to import
+	importId := step.ImportStateId
+	if importId == "" {
+		resource, err := testResource(step, state)
+		if err != nil {
+			return state, err
+		}
+
+		importId = resource.Primary.ID
+	}
+
+	// Setup the context. We initialize with an empty state. We use the
+	// full config for provider configurations.
+	mod, err := testModule(opts, step)
+	if err != nil {
+		return state, err
+	}
+
+	opts.Module = mod
+	opts.State = terraform.NewState()
+	ctx, err := terraform.NewContext(&opts)
+	if err != nil {
+		return state, err
+	}
+
+	// Do the import!
+	newState, err := ctx.Import(&terraform.ImportOpts{
+		// Set the module so that any provider config is loaded
+		Module: mod,
+
+		Targets: []*terraform.ImportTarget{
+			&terraform.ImportTarget{
+				Addr: step.ResourceName,
+				ID:   importId,
+			},
+		},
+	})
+	if err != nil {
+		log.Printf("[ERROR] Test: ImportState failure: %s", err)
+		return state, err
+	}
+
+	// Go through the new state and verify
+	if step.ImportStateCheck != nil {
+		var states []*terraform.InstanceState
+		for _, r := range newState.RootModule().Resources {
+			if r.Primary != nil {
+				states = append(states, r.Primary)
+			}
+		}
+		if err := step.ImportStateCheck(states); err != nil {
+			return state, err
+		}
+	}
+
+	// Verify that all the states match
+	if step.ImportStateVerify {
+		new := newState.RootModule().Resources
+		old := state.RootModule().Resources
+		for _, r := range new {
+			// Find the existing resource
+			var oldR *terraform.ResourceState
+			for _, r2 := range old {
+				if r2.Primary != nil && r2.Primary.ID == r.Primary.ID && r2.Type == r.Type {
+					oldR = r2
+					break
+				}
+			}
+			if oldR == nil {
+				return state, fmt.Errorf(
+					"Failed state verification, resource with ID %s not found",
+					r.Primary.ID)
+			}
+
+			// Compare their attributes
+			actual := make(map[string]string)
+			for k, v := range r.Primary.Attributes {
+				actual[k] = v
+			}
+			expected := make(map[string]string)
+			for k, v := range oldR.Primary.Attributes {
+				expected[k] = v
+			}
+
+			// Remove fields we're ignoring
+			for _, v := range step.ImportStateVerifyIgnore {
+				for k, _ := range actual {
+					if strings.HasPrefix(k, v) {
+						delete(actual, k)
+					}
+				}
+				for k, _ := range expected {
+					if strings.HasPrefix(k, v) {
+						delete(expected, k)
+					}
+				}
+			}
+
+			if !reflect.DeepEqual(actual, expected) {
+				// Determine only the different attributes
+				for k, v := range expected {
+					if av, ok := actual[k]; ok && v == av {
+						delete(expected, k)
+						delete(actual, k)
+					}
+				}
+
+				spewConf := spew.NewDefaultConfig()
+				spewConf.SortKeys = true
+				return state, fmt.Errorf(
+					"ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected."+
+						"\n\n%s\n\n%s",
+					spewConf.Sdump(actual), spewConf.Sdump(expected))
+			}
+		}
+	}
+
+	// Return the old state (non-imported) so we don't change anything.
+	return state, nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/resource/wait.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/wait.go
@@ -1,0 +1,84 @@
+package resource
+
+import (
+	"sync"
+	"time"
+)
+
+// Retry is a basic wrapper around StateChangeConf that will just retry
+// a function until it no longer returns an error.
+func Retry(timeout time.Duration, f RetryFunc) error {
+	// These are used to pull the error out of the function; need a mutex to
+	// avoid a data race.
+	var resultErr error
+	var resultErrMu sync.Mutex
+
+	c := &StateChangeConf{
+		Pending:    []string{"retryableerror"},
+		Target:     []string{"success"},
+		Timeout:    timeout,
+		MinTimeout: 500 * time.Millisecond,
+		Refresh: func() (interface{}, string, error) {
+			rerr := f()
+
+			resultErrMu.Lock()
+			defer resultErrMu.Unlock()
+
+			if rerr == nil {
+				resultErr = nil
+				return 42, "success", nil
+			}
+
+			resultErr = rerr.Err
+
+			if rerr.Retryable {
+				return 42, "retryableerror", nil
+			}
+			return nil, "quit", rerr.Err
+		},
+	}
+
+	_, waitErr := c.WaitForState()
+
+	// Need to acquire the lock here to be able to avoid race using resultErr as
+	// the return value
+	resultErrMu.Lock()
+	defer resultErrMu.Unlock()
+
+	// resultErr may be nil because the wait timed out and resultErr was never
+	// set; this is still an error
+	if resultErr == nil {
+		return waitErr
+	}
+	// resultErr takes precedence over waitErr if both are set because it is
+	// more likely to be useful
+	return resultErr
+}
+
+// RetryFunc is the function retried until it succeeds.
+type RetryFunc func() *RetryError
+
+// RetryError is the required return type of RetryFunc. It forces client code
+// to choose whether or not a given error is retryable.
+type RetryError struct {
+	Err       error
+	Retryable bool
+}
+
+// RetryableError is a helper to create a RetryError that's retryable from a
+// given error.
+func RetryableError(err error) *RetryError {
+	if err == nil {
+		return nil
+	}
+	return &RetryError{Err: err, Retryable: true}
+}
+
+// NonRetryableError is a helper to create a RetryError that's _not)_ retryable
+// from a given error.
+func NonRetryableError(err error) *RetryError {
+	if err == nil {
+		return nil
+	}
+	return &RetryError{Err: err, Retryable: false}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -345,6 +345,12 @@
 			"revisionTime": "2017-03-02T18:46:09Z"
 		},
 		{
+			"checksumSHA1": "vt+P9D2yWDO3gdvdgCzwqunlhxU=",
+			"path": "github.com/hashicorp/logutils",
+			"revision": "0dc08b1671f34c4250ce212759ebd880f743d883",
+			"revisionTime": "2015-06-09T07:04:31Z"
+		},
+		{
 			"checksumSHA1": "qBDBuBUz/eexkSEBpGpwhzzUqao=",
 			"path": "github.com/hashicorp/terraform/config",
 			"revision": "403a86dc557fae52f8e39676b11e1e4356b7d1a2",
@@ -369,6 +375,12 @@
 			"revisionTime": "2017-03-02T18:46:09Z"
 		},
 		{
+			"checksumSHA1": "uT6Q9RdSRAkDjyUgQlJ2XKJRab4=",
+			"path": "github.com/hashicorp/terraform/helper/config",
+			"revision": "0cc9e050ecd4a46ba6448758c2edc0b29bef5695",
+			"revisionTime": "2018-05-03T10:44:00Z"
+		},
+		{
 			"checksumSHA1": "3paXG5PoE+gIqEcjTyj5g+1VdaY=",
 			"path": "github.com/hashicorp/terraform/helper/experiment",
 			"revision": "403a86dc557fae52f8e39676b11e1e4356b7d1a2",
@@ -385,6 +397,20 @@
 			"path": "github.com/hashicorp/terraform/helper/hilmapstructure",
 			"revision": "403a86dc557fae52f8e39676b11e1e4356b7d1a2",
 			"revisionTime": "2017-03-02T18:46:09Z"
+		},
+		{
+			"checksumSHA1": "BAXV9ruAyno3aFgwYI2/wWzB2Gc=",
+			"path": "github.com/hashicorp/terraform/helper/logging",
+			"revision": "0cc9e050ecd4a46ba6448758c2edc0b29bef5695",
+			"revisionTime": "2018-05-03T10:44:00Z"
+		},
+		{
+			"checksumSHA1": "Nb3GUzvifZ0t8dzn7gsYPaAzk/o=",
+			"path": "github.com/hashicorp/terraform/helper/resource",
+			"revision": "403a86dc557fae52f8e39676b11e1e4356b7d1a2",
+			"revisionTime": "2017-03-02T18:46:09Z",
+			"version": "v0.8.8",
+			"versionExact": "v0.8.8"
 		},
 		{
 			"checksumSHA1": "QQsXmqgnDRaxos6tsZEuR/5AF0M=",

--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -2,8 +2,8 @@
 PROJECT = terraform-provider-cloudhealth
 
 VERSION = 2.0
-ITERATION = yelp0
-TFVERSION = 0.10
+ITERATION = yelp1
+TFVERSION = 0.8
 ARCH := $(shell facter architecture)
 
 PACKAGE_NAME := $(PROJECT)-${TFVERSION}_$(VERSION)-$(ITERATION)_$(ARCH).deb


### PR DESCRIPTION
More details in individual commits, in summary

Fix a bug with with cloudhealth and ref_ids for newly created groups - cloudhealths api changed to stop allowing the uuid we were suing to signify this was a new group - we now use an integer as suggested by cloudhealth

Add a very basic acceptance test to create a perspective in cloudhealth - this uses the terraform acceptance test framework to test we are creating a perspective correctly
