### PR TITLE
Stop writing cht_update.json

### DIFF
--- a/cloudhealth/resource_cht_perspective.go
+++ b/cloudhealth/resource_cht_perspective.go
@@ -258,8 +258,6 @@ func resourceCHTPerspectiveUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	ioutil.WriteFile("cht_update.json", pj, 0644)
-
 	id, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return fmt.Errorf("Failed to parse %s as int because %s", d.Id(), err)

--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -2,7 +2,7 @@
 PROJECT = terraform-provider-cloudhealth
 
 VERSION = 3.0
-ITERATION = yelp1
+ITERATION = yelp2
 TFVERSION = 0.10
 ARCH := $(shell facter architecture)
 


### PR DESCRIPTION
This file is used for debugging what is sent to the cloudhealth api
only, it is not used by the provider at all. Its better to use terraform
logging for this.