### PR TITLE
Fix jenkins build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/Yelp/terraform-provider-cloudhealth
 
+go 1.14
+
 require (
 	github.com/hashicorp/terraform v0.12.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,7 @@ google.golang.org/api v0.1.0/go.mod h1:UGEZY7KEX120AnNLIHFMKIo4obdJhkp2tPbaPlQx1
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -21,7 +21,7 @@ $(PACKAGE_FILE): .docker_container_id
 
 .docker_container_id: .docker_image_id
 	docker run --rm=false \
-		-v $(CURDIR)/..:/go/src/github.com/Yelp/terraform-provider-cloudhealth:ro \
+		-v $(CURDIR)/..:/code \
 		-v $(CURDIR)/build.sh:/build.sh:ro \
 		--cidfile=$(CURDIR)/.docker_container_id \
 		$$(cat .docker_image_id) \

--- a/yelppack/build.sh
+++ b/yelppack/build.sh
@@ -5,7 +5,8 @@ version=$2
 iteration=$3
 tf_version=$4
 
-go get github.com/Yelp/${project}
+cd /code
+make
 mkdir /dist && cd /dist
 mkdir /tmp/usrbin
 


### PR DESCRIPTION
Adding the code inside gopath and then using `go get` to build it
doesn't seem to work anymore in newer go versions. Or maybe it interacts
badly with go modules.

Anyway it's a weird thing to do when you can simply cd in that folder
and run `make`