### PR TITLE
Remove Terraform version namespace from package name

### DIFF
--- a/yelppack/Makefile
+++ b/yelppack/Makefile
@@ -6,29 +6,20 @@ PROJECT = cloudhealth
 
 VERSION = 4.4
 ITERATION = yelp2
-TF_VERSIONS = 0.12 0.13
 ARCH := $(shell facter architecture)
 
-PACKAGE_NAMES := $(foreach TF_VERSION,$(TF_VERSIONS),terraform-provider-$(PROJECT)-$(TF_VERSION)_$(VERSION)-$(ITERATION)_amd64.deb)
-PACKAGE_FILES := $(foreach PACKAGE_NAME,$(PACKAGE_NAMES),dist/$(PACKAGE_NAME))
+PACKAGE_NAME := terraform-provider-$(PROJECT)_$(VERSION)-$(ITERATION)_amd64.deb
 
 DOCKER_TAG = terraform-provider-$(PROJECT)_$(shell date +%s)
 
 CLEAN_CONTAINER := [ -e .docker_container_id ] && docker rm --force $$(cat .docker_container_id) || true; rm -f .docker_container_id
 
-itest_%: $(PACKAGE_FILES)
-	export TF_VERSIONS=( $(TF_VERSIONS) ) && \
-	export PACKAGE_FILES=( $(PACKAGE_FILES) ) && \
-	export VERSION=( $(VERSION) ) && \
-	for ((i=0; i<$${#TF_VERSIONS[@]}; ++i)); do \
-		docker run --rm -v $(CURDIR)/../dist:/dist:ro -v $(CURDIR)/itest.sh:/itest.sh:ro docker-dev.yelpcorp.com/$*_yelp:latest bash /itest.sh /$${PACKAGE_FILES[i]} $${TF_VERSIONS[i]} $${VERSION}; \
-	done
+itest_%: dist/%/$(PACKAGE_NAME)
+	docker run --rm -v $(CURDIR)/../dist:/dist:ro -v $(CURDIR)/itest.sh:/itest.sh:ro docker-dev.yelpcorp.com/$*_yelp:latest bash /itest.sh /dist/$*/$(PACKAGE_NAME) $(VERSION)
 
-$(PACKAGE_FILES): .docker_container_id
-	mkdir -p ../dist && \
-	for PACKAGE_FILE in $(PACKAGE_FILES); do \
-		docker cp $$(cat .docker_container_id):/$$PACKAGE_FILE ../dist/; \
-	done
+dist/%/$(PACKAGE_NAME): .docker_container_id
+	mkdir -p ../dist/$* && \
+	docker cp $$(cat .docker_container_id):/dist/$(PACKAGE_NAME) ../dist/$*/
 
 .docker_container_id: .docker_image_id
 	docker run --rm=false \

--- a/yelppack/build.sh
+++ b/yelppack/build.sh
@@ -5,23 +5,15 @@ project=$1 ; shift
 version=$1 ; shift
 iteration=$1 ; shift
 
-tf_versions="$@"
-
 go build -v -o /go/bin/terraform-provider-${project}
 
 mkdir /dist && cd /dist
 
-for tf_version in $tf_versions; do
-    echo "Terraform version is ${tf_version}"
-    if [[ ${tf_version} == "0.12" ]] ; then
-        install_path="/nail/opt/terraform-${tf_version}/bin/"
-    else
-        install_path="/usr/local/share/terraform/plugins/terraform-registry.yelpcorp.com/yelp/${project}/${version}/linux_amd64/"
-    fi
-    echo "Install path is ${install_path}"
+install_path="/usr/local/share/terraform/plugins/terraform-registry.yelpcorp.com/yelp/${project}/${version}/linux_amd64/"
+echo "Install path is ${install_path}"
 
-    fpm -s dir -t deb --deb-no-default-config-files --name terraform-provider-${project}-${tf_version} \
-      --iteration ${iteration} --version ${version} \
-      /go/bin/terraform-provider-${project}=${install_path}
-done
+fpm -s dir -t deb --deb-no-default-config-files --name terraform-provider-${project} \
+  --iteration ${iteration} --version ${version} \
+  /go/bin/terraform-provider-${project}=${install_path}
+
 ls /dist

--- a/yelppack/itest.sh
+++ b/yelppack/itest.sh
@@ -3,14 +3,9 @@
 set -eu
 
 package=$1
-tfversion=$2
-version=$3
+version=$2
 
-if [[ ${tfversion} == "0.12" ]] ; then
-    install_path="/nail/opt/terraform-${tfversion}/bin/terraform-provider-cloudhealth"
-else
-    install_path="/usr/local/share/terraform/plugins/terraform-registry.yelpcorp.com/yelp/cloudhealth/${version}/linux_amd64/terraform-provider-cloudhealth"
-fi
+install_path="/usr/local/share/terraform/plugins/terraform-registry.yelpcorp.com/yelp/cloudhealth/${version}/linux_amd64/terraform-provider-cloudhealth"
 
 dpkg -i "$package"
 ls -la $install_path


### PR DESCRIPTION
For building this package within Yelp, we should not include a Terraform version within. This drops that and stops building for Terraform 0.12.